### PR TITLE
feat(scripts): add unified JSX runner for AE/PS/AI

### DIFF
--- a/scripts/run_jsx.zsh
+++ b/scripts/run_jsx.zsh
@@ -1,0 +1,51 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "❌ استخدم: $0 [ae|ps|ai] filename.jsx"
+  exit 1
+fi
+
+TARGET="$1"
+JSX_ARG="$2"
+
+case "$TARGET" in
+  ae)
+    APP="Adobe After Effects 2024"
+    DEFAULT_BASE="$HOME/interactive-packaging-agent/scripts/aftereffects"
+    ;;
+  ps)
+    APP="Adobe Photoshop 2024"
+    DEFAULT_BASE="$HOME/interactive-packaging-agent/scripts/photoshop"
+    ;;
+  ai)
+    APP="Adobe Illustrator 2024"
+    DEFAULT_BASE="$HOME/interactive-packaging-agent/scripts/illustrator"
+    ;;
+  *)
+    echo "❌ استخدم: $0 [ae|ps|ai] filename.jsx"
+    exit 1
+    ;;
+esac
+
+if [[ "$JSX_ARG" = /* || "$JSX_ARG" = .* ]]; then
+  SCRIPT_PATH="$(cd "$(dirname "$JSX_ARG")" && pwd)/$(basename "$JSX_ARG")"
+else
+  SCRIPT_PATH="$DEFAULT_BASE/$JSX_ARG"
+fi
+
+if [ ! -f "$SCRIPT_PATH" ]; then
+  echo "⚠️ الملف غير موجود: $SCRIPT_PATH"
+  exit 1
+fi
+
+echo "🚀 تشغيل: $SCRIPT_PATH داخل $APP"
+
+if [ "$TARGET" = "ae" ]; then
+  osascript -e "tell application \"$APP\" to DoScriptFile \"$SCRIPT_PATH\""
+else
+  osascript -e "tell application \"$APP\" to do javascript POSIX file \"$SCRIPT_PATH\""
+fi
+
+echo "✅ تم التنفيذ بنجاح"


### PR DESCRIPTION
Add scripts/run_jsx.zsh - سكربت موحّد لتشغيل ملفات JSX في Adobe After Effects وPhotoshop وIllustrator.

- يدعم تمرير اسم الملف أو مسار كامل
- يستخدم DoScriptFile لـ After Effects و do javascript لـ Photoshop/Illustrator
- يتحقق من وجود الملفات قبل التشغيل
- رسائل عربية واضحة للمستخدم

الاستخدام:
./scripts/run_jsx.zsh ae template_builder.jsx
./scripts/run_jsx.zsh ps template_builder.jsx
./scripts/run_jsx.zsh ai template_builder.jsx